### PR TITLE
Refactor auth failure and course configuration paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ django-lti-provider offers:
 
 The library is used at Columbia University's [Center for Teaching And Learning](http://ctl.columbia.edu) in [Mediathread](http://www.github.com/ccnmtl/mediathread).
 
+See an example Django app using the library at https://github.com/ccnmtl/django-lti-provider-example.
 
 ## Installation
 
@@ -58,6 +59,11 @@ AUTHENTICATION_BACKENDS = [
 ]
 ```
 
+Complete a migration
+```python
+   ./manage.py migrate
+```
+
 ```
 The ``LTI_TOOL_CONFIGURATION`` variable in your ``settings.py`` allows you to
 configure your application's config.xml. ([Edu Apps](https://www.edu-apps.org/code.html) has good documentation
@@ -65,20 +71,21 @@ on configuring an lti provider through xml.)
 ```
 LTI_TOOL_CONFIGURATION = {
     'title': '<your lti provider title>',
-    'description': '<your description>'
+    'description': '<your description>',
     'launch_url': 'lti/',
     'embed_url': '<the view endpoint for an embed tool>' or '',
     'embed_icon_url': '<the icon url to use for an embed tool>' or '',
     'embed_tool_id': '<the embed tool id>' or '',
     'landing_url': '<the view landing page>',
-    'course_aware': '<True or False>',
-    'course_navigation': '<True or False>',
-    'assignment_new_tab': '<True or False>',
+    'course_aware': <True or False>,
+    'course_navigation': <True or False>,
+    'new_tab': <True or False>,
     'frame_width': <width in pixels>,
     'frame_height': <height in pixels>
 }
 
-To pass through extra LTI parameters to your provider, populate the LTI_EXTRA_PARAMETERS variable in your settings.py
+To pass through extra LTI parameters to your provider, populate the LTI_EXTRA_PARAMETERS variable in your settings.py.
+This is useful for custom parameters you may specify at installation time.
 
 LTI_EXTRA_PARAMETERS = ['lti_version']
 

--- a/lti_provider/mixins.py
+++ b/lti_provider/mixins.py
@@ -1,0 +1,52 @@
+from django.conf import settings
+from django.contrib.auth import authenticate, login
+from django.core.urlresolvers import reverse
+from django.http.response import HttpResponseRedirect
+from lti_provider.lti import LTI
+from lti_provider.models import LTICourseContext
+
+
+class LTIAuthMixin(object):
+    role_type = 'any'
+    request_type = 'any'
+
+    def join_groups(self, request, lti, ctx):
+        # add the user to the requested groups
+        request.user.groups.add(ctx.group)
+        for role in lti.user_roles(request):
+            role = role.lower()
+            if ('staff' in role or
+                'instructor' in role or
+                    'administrator' in role):
+                request.user.groups.add(ctx.faculty_group)
+                break
+
+    def course_configuration(self, request, lti):
+        # check if course is configured
+        if settings.LTI_TOOL_CONFIGURATION['course_aware']:
+            ctx = LTICourseContext.objects.get(
+                lms_course_context=lti.course_context(request))
+
+            # add user to the course
+            self.join_groups(request, lti, ctx)
+
+    def dispatch(self, request, *args, **kwargs):
+        lti = LTI(self.request_type, self.role_type)
+
+        # validate the user via oauth
+        user = authenticate(request=request, lti=lti)
+        if user is None:
+            lti.clear_session(request)
+            return HttpResponseRedirect(reverse('lti-fail-auth'))
+
+        # login
+        login(request, user)
+
+        # configure course groups if requested
+        try:
+            self.course_configuration(request, lti)
+        except (KeyError, ValueError, LTICourseContext.DoesNotExist):
+            return HttpResponseRedirect(reverse('lti-course-config'))
+
+        self.lti = lti
+        return super(LTIAuthMixin, self).dispatch(request, *args, **kwargs)

--- a/lti_provider/templates/lti_provider/config.xml
+++ b/lti_provider/templates/lti_provider/config.xml
@@ -16,7 +16,7 @@
       <lticm:property name="text">{% if debug %}Dev{% endif %} {{title}}</lticm:property>
       <lticm:property name="selection_width">{{frame_width}}</lticm:property>
       <lticm:property name="selection_height">{{frame_height}}</lticm:property>
-      {% if course_navigation %} 
+      {% if navigation %} 
       <lticm:options name="course_navigation">
         <lticm:property name="default">disabled</lticm:property>
         <lticm:property name="enabled">true</lticm:property>

--- a/lti_provider/urls.py
+++ b/lti_provider/urls.py
@@ -1,14 +1,17 @@
 from django.conf.urls import url
 
 from lti_provider.views import LTIConfigView, LTILandingPage, LTIRoutingView, \
-    LTICourseEnableView, LTIPostGrade
+    LTICourseEnableView, LTIPostGrade, LTIFailAuthorization, LTICourseConfigure
 
 
 urlpatterns = [
     url(r'^config.xml$', LTIConfigView.as_view(), {}, 'lti-config'),
-    url(r'^enable/$', LTICourseEnableView.as_view(), {}, 'lti-enable-course'),
-    url(r'^landing/(?P<context>\w[^/]*)/$',
-        LTILandingPage.as_view(), {}, 'lti-landing-page'),
+    url(r'^auth$', LTIFailAuthorization.as_view(), {}, 'lti-fail-auth'),
+    url(r'^course/config$',
+        LTICourseConfigure.as_view(), {}, 'lti-course-config'),
+    url(r'^course/enable/$',
+        LTICourseEnableView.as_view(), {}, 'lti-course-enable'),
+    url(r'^landing/$', LTILandingPage.as_view(), {}, 'lti-landing-page'),
     url('^grade/$', LTIPostGrade.as_view(), {}, 'lti-post-grade'),
     url(r'^$', LTIRoutingView.as_view(), {}, 'lti-login'),
 ]


### PR DESCRIPTION
Handling both paths more cleanly with redirect logic.

Also...
* Move the LTIAuthMixin into a separate file for clarity
* Course configuration can use session variables to populate the template
* Update README