### PR TITLE
Remove oauth dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Add to ```INSTALLED_APPS``` in your ```settings.py```::
 * Django
 * nameparser
 * httplib2
-* oauth
 * oauth2
 * oauthlib
 * pylti

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         "Django",
         "nameparser",
         "httplib2",
-        "oauth",
         "oauth2",
         "oauthlib",
         "pylti",

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -2,10 +2,9 @@ Django==1.11.6
 six==1.11.0
 nameparser==0.5.3
 httplib2==0.10.3
-oauth==1.0.1
 oauth2==1.9.0.post1
 oauthlib==2.0.6
-pylti>=0.1.3
+pylti==0.5.0
 ipaddress==1.0.18
 python-dateutil==2.6.1
 text-unidecode==1.0  # for faker


### PR DESCRIPTION
As of version 0.5.0 of the pylti library, it no longer depends on the
oauth library.