### PR TITLE
Make LTI routing view exempt from CSRF

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 0.2.1
 ===================
 * Python 3 fix: items() instead of iteritems()
+* Make LTIRoutingView exempt from CSRF checks
 
 0.2.0  (2017-10-20)
 ===================

--- a/lti_provider/views.py
+++ b/lti_provider/views.py
@@ -8,6 +8,7 @@ from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import View, TemplateView
 from lti_provider.mixins import LTIAuthMixin
 from lti_provider.models import LTICourseContext
@@ -45,6 +46,10 @@ class LTIConfigView(TemplateView):
 class LTIRoutingView(LTIAuthMixin, View):
     request_type = 'initial'
     role_type = 'any'
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        return super(LTIRoutingView, self).dispatch(*args, **kwargs)
 
     def add_custom_parameters(self, url):
         if not hasattr(settings, 'LTI_EXTRA_PARAMETERS'):


### PR DESCRIPTION
As far as I know, the LTI consumer can't know the CSRF value when making
the POST request, so make this view exempt from this check.

This fixes the landing page in my testing with econplayground.