### PR TITLE
Fix encoding error in python 3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.2.2
+===================
+* Fixed an encoding error on LTI init in Python 3
+
 0.2.1  (2017-10-26)
 ===================
 * Python 3 fix: items() instead of iteritems()

--- a/lti_provider/auth.py
+++ b/lti_provider/auth.py
@@ -1,6 +1,7 @@
 from hashlib import sha1
 
 from django.contrib.auth.models import User
+from django.utils.encoding import force_bytes
 from nameparser import HumanName
 from pylti.common import LTIException
 
@@ -25,7 +26,7 @@ class LTIBackend(object):
         # generate a username to avoid overlap with existing system usernames
         # sha1 hash result + trunc to 30 chars should result in a valid
         # username with low-ish-chance of collisions
-        uid = lti.consumer_user_id(request)
+        uid = force_bytes(lti.consumer_user_id(request))
         return sha1(uid).hexdigest()[:30]
 
     def get_username(self, request, lti):


### PR DESCRIPTION
> TypeError: Unicode-objects must be encoded before hashing
> (11 additional frame(s) were not displayed)
> ...
> File "lti_provider/mixins.py", line 37, in dispatch
> user = authenticate(request=request, lti=lti)
> File "lti_provider/auth.py", line 65, in authenticate
> return self.find_or_create_user(request, lti)
> File "lti_provider/auth.py", line 55, in
> find_or_create_user
> user = self.find_user(request, lti)
> File "lti_provider/auth.py", line 49, in find_user
> username = self.get_hashed_username(request,
> lti)
> File "lti_provider/auth.py", line 29, in
> get_hashed_username
> return sha1(uid).hexdigest()[:30]