### PR TITLE
If score is an empty string, interpret it as 0

### DIFF
--- a/lti_provider/views.py
+++ b/lti_provider/views.py
@@ -155,11 +155,14 @@ class LTIPostGrade(LTIAuthMixin, View):
         """
         Post grade to LTI consumer using XML
 
-        :param: grade: 0 <= grade <= 1
-        :return: True if post successful and grade valid
+        :param: score: 0 <= score <= 1
+        :return: True if post successful and score valid
         :exception: LTIPostMessageException if call failed
         """
-        score = float(request.POST.get('score'))
+        try:
+            score = float(request.POST.get('score'))
+        except ValueError:
+            score = 0
 
         xml = generate_request_xml(
             self.message_identifier(), 'replaceResult',


### PR DESCRIPTION
Also, in the comments here, the param was listed as 'grade'. I've
changed it to 'score' since it looks like that's what the code is
expecting.