### PR TITLE
Add full request verification when oauth is present

### DIFF
--- a/lti_provider/tests/test_lti.py
+++ b/lti_provider/tests/test_lti.py
@@ -59,6 +59,16 @@ class LTITest(TestCase):
         with self.settings(PYLTI_CONFIG={'consumers': CONSUMERS}):
             self.assertEquals(self.lti.consumers(), CONSUMERS)
 
+    def test_params(self):
+        factory = RequestFactory()
+        request = factory.post('/', {'post': 'data'})
+        params = self.lti._params(request)
+        self.assertTrue('post' in params)
+
+        request = factory.post('/', {'get': 'data'})
+        params = self.lti._params(request)
+        self.assertTrue('get' in params)
+
     def test_verify_any(self):
         lti = LTI('any', 'any')
         request = generate_lti_request()


### PR DESCRIPTION
This (quickly) corrects an assumption that once the LTI provider makes a single oAuth launch request, the resulting established session is valid for all subsequent requests. Actually, the LTI provider makes many oAuth launch requests that contain parameters applicable only for that launch context, e.g. a given assignment.

Longer term, the LTI object's `request_type` attribute with values of `initial`, `any` or `session` should be removed in favor of a quick peek at the request.