### PR TITLE
MySQL support: add the lms_course_context as a CharField

### DIFF
--- a/lti_provider/migrations/0005_auto_20171009_1234.py
+++ b/lti_provider/migrations/0005_auto_20171009_1234.py
@@ -5,6 +5,26 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 
 
+class MySQLAddLMSCourseContext(migrations.AddField):
+
+    def database_forwards(
+            self, app_label, schema_editor, from_state, to_state):
+
+        if schema_editor.connection.vendor.startswith("mysql"):
+            super(MySQLAddLMSCourseContext, self).database_forwards(
+                app_label, schema_editor, from_state, to_state)
+
+
+class PostgresAddLMSCourseContext(migrations.AddField):
+
+    def database_forwards(
+            self, app_label, schema_editor, from_state, to_state):
+
+        if schema_editor.connection.vendor.startswith("postgres"):
+            super(PostgresAddLMSCourseContext, self).database_forwards(
+                app_label, schema_editor, from_state, to_state)
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -20,9 +40,14 @@ class Migration(migrations.Migration):
             model_name='lticoursecontext',
             name='uuid',
         ),
-        migrations.AddField(
+        PostgresAddLMSCourseContext(
             model_name='lticoursecontext',
             name='lms_course_context',
-            field=models.TextField(null=True, unique=True),
+            field=models.TextField(null=True, unique=True)
         ),
+        MySQLAddLMSCourseContext(
+            model_name='lticoursecontext',
+            name='lms_course_context',
+            field=models.CharField(max_length=255, null=True, unique=True)
+        )
     ]


### PR DESCRIPTION
The Postgres 0005 and 0006 flows remain unchanged, and leave the
lms_course_context correctly altered to a CharField.

The MySQL 0005 patch adds the field as a CharField. The 0006 patch
acts as a no-op.

This should address the migration errors reported in https://github.com/ccnmtl/django-lti-provider/issues/105

Using pattern from ShaggyFrog: https://stackoverflow.com/a/37740152.