### PR TITLE
Fix course-aware flow

### DIFF
--- a/lti_provider/mixins.py
+++ b/lti_provider/mixins.py
@@ -53,3 +53,23 @@ class LTIAuthMixin(object):
 
         self.lti = lti
         return super(LTIAuthMixin, self).dispatch(request, *args, **kwargs)
+
+
+class LTILoggedInMixin(object):
+    role_type = 'any'
+    request_type = 'any'
+
+    def dispatch(self, request, *args, **kwargs):
+        lti = LTI(self.request_type, self.role_type)
+
+        # validate the user via oauth
+        user = authenticate(request=request, lti=lti)
+        if user is None:
+            lti.clear_session(request)
+            return HttpResponseRedirect(reverse('lti-fail-auth'))
+
+        # login
+        login(request, user)
+
+        self.lti = lti
+        return super(LTILoggedInMixin, self).dispatch(request, *args, **kwargs)

--- a/lti_provider/views.py
+++ b/lti_provider/views.py
@@ -10,7 +10,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import View, TemplateView
-from lti_provider.mixins import LTIAuthMixin
+from lti_provider.mixins import LTIAuthMixin, LTILoggedInMixin
 from lti_provider.models import LTICourseContext
 from pylti.common import LTIPostMessageException, post_message
 
@@ -118,7 +118,7 @@ class LTIFailAuthorization(TemplateView):
 
 
 @method_decorator(xframe_options_exempt, name='dispatch')
-class LTICourseConfigure(LTIAuthMixin, TemplateView):
+class LTICourseConfigure(LTILoggedInMixin, TemplateView):
     template_name = 'lti_provider/fail_course_configuration.html'
 
     def get_context_data(self, **kwargs):
@@ -134,7 +134,7 @@ class LTICourseConfigure(LTIAuthMixin, TemplateView):
 
 
 @method_decorator(xframe_options_exempt, name='dispatch')
-class LTICourseEnableView(LTIAuthMixin, View):
+class LTICourseEnableView(LTILoggedInMixin, View):
 
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -7,7 +7,7 @@ pylti==0.7.0
 ipaddress==1.0.23
 python-dateutil==2.8.1
 text-unidecode==1.3  # for faker
-faker==4.0.0
+faker==3.0.1 # pyup: <4.0.0
 factory-boy==2.12.0
 coverage==5.0.3
 mccabe==0.6.1


### PR DESCRIPTION
The course configure and enable views were infinitely trying to configure themselves. Provide a mixin that just verifies the user is logged in and has an LTI session.