### PR TITLE
travis: remove Django 2.0 testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.6"
 env:
   - DJANGO="Django>=1.11.0,<1.12.0"
-  - DJANGO="Django>=2.0,<2.1"
   - DJANGO="Django>=2.2,<2.3"
 script:
   - make


### PR DESCRIPTION
Django 2.0's upstream support has ended, so we can remove it from travis. https://www.djangoproject.com/download/