### PR TITLE
Some README adds

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ To stash custom properties in your session, populate the `LTI_PROPERTY_LIST_EX` 
 LTI_PROPERTY_LIST_EX = ['custom_parameter1', 'custom_parameter2']
 ```
 
+Please note that you will need to add the following settings in your applications `settings.py`:
+
+```
+SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+SESSION_COOKIE_SAMESITE = None
+```
+
+Because Canvas sends the information that we are storing in a `POST` request on the LTI launch, we need to disable the restriction on cookies only being allowed to be set from the same site. For more information on this [read here](https://docs.djangoproject.com/en/3.0/ref/settings/#session-cookie-samesite).
+
 To specify a custom username property, add the `LTI_PROPERTY_USER_USERNAME` variable to your `settings.py`. By default, `LTI_PROPERTY_USER_USERNAME` is `custom_canvas_user_login_id`. This value can vary depending on your LMS.
 
 To pass through extra LTI parameters to your provider, populate the `LTI_EXTRA_PARAMETERS` variable in your `settings.py`.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ PYLTI_CONFIG = {
 }
 ```
 
+Additionally you will need to make sure to add the following to your `settings.py` file:
+
+```
+X_FRAME_OPTIONS = "ALLOW-FROM https://<your-org-subdomain>.instructure.com"
+```
+
+This ensures that the Django application will allow requests from your orgs Canvas instance. For more on `X_FRAME_OPTIONS` please [consult here](https://docs.djangoproject.com/en/3.0/ref/clickjacking/#module-django.middleware.clickjacking). 
+
 ## Assignments
 
 To support multiple assignments: 


### PR DESCRIPTION
I noticed that when I was building a simple application from the ground up, the session was not being populated when I was connecting to a basic app from Canvas. I added a link to the Django docs that helped me figure this out as well as a small explanation that users need to tune certain values, and what the justification is.

If I'm missing a better way of doing this, please let me know! I.e. maybe there is something a bit more conservative to do about the `SESSION_COOKIE_SAMESITE` variable. Right now I've just disabled it entirely.

I also added some notes about `X_FRAME_OPTIONS`. I had to add a rule so that the Django allows Canvas to access the application via an iframe.

Glad to re-organize these a bit upon your feedback. I threw these together real quick.