### PR TITLE
Fix course_navigation property not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ LTI_TOOL_CONFIGURATION = {
     'embed_tool_id': '<the embed tool id>' or '',
     'landing_url': '<the view landing page>',
     'course_aware': <True or False>,
-    'navigation': <True or False>,
+    'course_navigation': <True or False>,
     'new_tab': <True or False>,
     'frame_width': <width in pixels>,
     'frame_height': <height in pixels>,

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Complete a migration
 The ``LTI_TOOL_CONFIGURATION`` variable in your ``settings.py`` allows you to
 configure your application's config.xml and set other options for the library. ([Edu Apps](https://www.edu-apps.org/code.html) has good documentation
 on configuring an lti provider through xml.)
-```
+```python
 LTI_TOOL_CONFIGURATION = {
     'title': '<your lti provider title>',
     'description': '<your description>',
@@ -75,7 +75,7 @@ LTI_TOOL_CONFIGURATION = {
     'embed_tool_id': '<the embed tool id>' or '',
     'landing_url': '<the view landing page>',
     'course_aware': <True or False>,
-    'course_navigation': <True or False>,
+    'navigation': <True or False>,
     'new_tab': <True or False>,
     'frame_width': <width in pixels>,
     'frame_height': <height in pixels>,

--- a/lti_provider/templates/lti_provider/config.xml
+++ b/lti_provider/templates/lti_provider/config.xml
@@ -17,7 +17,7 @@
       <lticm:property name="text">{% if debug %}Dev{% endif %} {{title}}</lticm:property>
       <lticm:property name="selection_width">{{frame_width}}</lticm:property>
       <lticm:property name="selection_height">{{frame_height}}</lticm:property>
-      {% if navigation %} 
+      {% if course_navigation %} 
       <lticm:options name="course_navigation">
         <lticm:property name="default">disabled</lticm:property>
         <lticm:property name="enabled">true</lticm:property>

--- a/lti_provider/tests/test_views.py
+++ b/lti_provider/tests/test_views.py
@@ -156,7 +156,9 @@ class LTIViewTest(TestCase):
             config_xml = response.content.decode()
 
             root = ET.fromstring(config_xml)
-            course_navigation_property = root.find(".//*[@name='course_navigation']")
-            enabled = course_navigation_property.find("./*[@name='enabled']").text
+            course_navigation_property = root.find(
+                    ".//*[@name='course_navigation']")
+            enabled = course_navigation_property.find(
+                    "./*[@name='enabled']").text
 
             self.assertEqual(enabled, 'true')

--- a/lti_provider/views.py
+++ b/lti_provider/views.py
@@ -43,7 +43,8 @@ class LTIConfigView(TemplateView):
             'frame_width': settings.LTI_TOOL_CONFIGURATION.get('frame_width'),
             'frame_height': settings.LTI_TOOL_CONFIGURATION.get(
                 'frame_height'),
-            'course_navigation': settings.LTI_TOOL_CONFIGURATION.get('course_navigation'),
+            'course_navigation': settings.LTI_TOOL_CONFIGURATION.get(
+                'course_navigation'),
             'custom_fields': settings.LTI_TOOL_CONFIGURATION.get(
                 'custom_fields')
         }

--- a/lti_provider/views.py
+++ b/lti_provider/views.py
@@ -43,7 +43,7 @@ class LTIConfigView(TemplateView):
             'frame_width': settings.LTI_TOOL_CONFIGURATION.get('frame_width'),
             'frame_height': settings.LTI_TOOL_CONFIGURATION.get(
                 'frame_height'),
-            'navigation': settings.LTI_TOOL_CONFIGURATION.get('navigation'),
+            'course_navigation': settings.LTI_TOOL_CONFIGURATION.get('course_navigation'),
             'custom_fields': settings.LTI_TOOL_CONFIGURATION.get(
                 'custom_fields')
         }


### PR DESCRIPTION
Using `course_navigation` as the key in the LTI configuration had no effect on the resulting `config.xml.`