### PR TITLE
Dynamic assignments - making the view a little bit more generic

### DIFF
--- a/lti_provider/urls.py
+++ b/lti_provider/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
     url(r'^landing/$', LTILandingPage.as_view(), {}, 'lti-landing-page'),
     url('^grade/$', LTIPostGrade.as_view(), {}, 'lti-post-grade'),
     url(r'^$', LTIRoutingView.as_view(), {}, 'lti-login'),
-    url(r'^assignment/(?P<assignment_name>.*)/(?P<assignment_id>\d+)/$',
+    url(r'^assignment/(?P<assignment_name>.*)/(?P<pk>\d+)/$',
         LTIRoutingView.as_view(), {}, 'lti-assignment-view'),
     url(r'^assignment/(?P<assignment_name>.*)/$',
         LTIRoutingView.as_view(), {}, 'lti-assignment-view')

--- a/lti_provider/views.py
+++ b/lti_provider/views.py
@@ -75,11 +75,10 @@ class LTIRoutingView(LTIAuthMixin, View):
 
         return url
 
-    def lookup_assignment_name(self, assignment_name, assignment_id):
+    def lookup_assignment_name(self, assignment_name, pk):
         try:
             # first see if there is a matching named view
-            url = reverse(
-                assignment_name, kwargs={'assignment_id': assignment_id})
+            url = reverse(assignment_name, kwargs={'pk': pk})
         except NoReverseMatch:
             # otherwise look it up.
             assignments = settings.LTI_TOOL_CONFIGURATION['assignments']
@@ -87,7 +86,7 @@ class LTIRoutingView(LTIAuthMixin, View):
 
         return url
 
-    def post(self, request, assignment_name=None, assignment_id=None):
+    def post(self, request, assignment_name=None, pk=None):
         if request.POST.get('ext_content_intended_use', '') == 'embed':
             domain = self.request.get_host()
             url = '%s://%s/%s?return_url=%s' % (
@@ -98,8 +97,8 @@ class LTIRoutingView(LTIAuthMixin, View):
             url = self.lookup_assignment_name(assignment_name, assignment_id)
         elif request.GET.get('assignment', None) is not None:
             assignment_name = request.GET.get('assignment')
-            assignment_id = request.GET.get('id')
-            url = self.lookup_assignment_name(assignment_name, assignment_id)
+            pk = request.GET.get('pk')
+            url = self.lookup_assignment_name(assignment_name, pk)
         elif settings.LTI_TOOL_CONFIGURATION.get('new_tab'):
             url = reverse('lti-landing-page')
         else:

--- a/lti_provider/views.py
+++ b/lti_provider/views.py
@@ -94,7 +94,7 @@ class LTIRoutingView(LTIAuthMixin, View):
                 settings.LTI_TOOL_CONFIGURATION.get('embed_url'),
                 request.POST.get('launch_presentation_return_url'))
         elif assignment_name:
-            url = self.lookup_assignment_name(assignment_name, assignment_id)
+            url = self.lookup_assignment_name(assignment_name, pk)
         elif request.GET.get('assignment', None) is not None:
             assignment_name = request.GET.get('assignment')
             pk = request.GET.get('pk')


### PR DESCRIPTION
Passing in a simple pk rather than a labeled "assignment_id" allows this view to also be used for submissions and the speedgrader.