### PR TITLE
Replaced deprecated url function with re_path

### DIFF
--- a/lti_provider/urls.py
+++ b/lti_provider/urls.py
@@ -1,21 +1,21 @@
-from django.conf.urls import url
+from django.conf.urls import re_path
 
 from lti_provider.views import LTIConfigView, LTILandingPage, LTIRoutingView, \
     LTICourseEnableView, LTIPostGrade, LTIFailAuthorization, LTICourseConfigure
 
 
 urlpatterns = [
-    url(r'^config.xml$', LTIConfigView.as_view(), {}, 'lti-config'),
-    url(r'^auth$', LTIFailAuthorization.as_view(), {}, 'lti-fail-auth'),
-    url(r'^course/config$',
+    re_path(r'^config.xml$', LTIConfigView.as_view(), {}, 'lti-config'),
+    re_path(r'^auth$', LTIFailAuthorization.as_view(), {}, 'lti-fail-auth'),
+    re_path(r'^course/config$',
         LTICourseConfigure.as_view(), {}, 'lti-course-config'),
-    url(r'^course/enable/$',
+    re_path(r'^course/enable/$',
         LTICourseEnableView.as_view(), {}, 'lti-course-enable'),
-    url(r'^landing/$', LTILandingPage.as_view(), {}, 'lti-landing-page'),
-    url('^grade/$', LTIPostGrade.as_view(), {}, 'lti-post-grade'),
-    url(r'^$', LTIRoutingView.as_view(), {}, 'lti-login'),
-    url(r'^assignment/(?P<assignment_name>.*)/(?P<pk>\d+)/$',
+    re_path(r'^landing/$', LTILandingPage.as_view(), {}, 'lti-landing-page'),
+    re_path('^grade/$', LTIPostGrade.as_view(), {}, 'lti-post-grade'),
+    re_path(r'^$', LTIRoutingView.as_view(), {}, 'lti-login'),
+    re_path(r'^assignment/(?P<assignment_name>.*)/(?P<pk>\d+)/$',
         LTIRoutingView.as_view(), {}, 'lti-assignment-view'),
-    url(r'^assignment/(?P<assignment_name>.*)/$',
+    re_path(r'^assignment/(?P<assignment_name>.*)/$',
         LTIRoutingView.as_view(), {}, 'lti-assignment-view')
 ]

--- a/lti_provider/urls.py
+++ b/lti_provider/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from lti_provider.views import LTIConfigView, LTILandingPage, LTIRoutingView, \
     LTICourseEnableView, LTIPostGrade, LTIFailAuthorization, LTICourseConfigure


### PR DESCRIPTION
This PR fixes the following deprecation warning seen in Django>=3.1:

```
RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path().
```

The [url()](https://docs.djangoproject.com/en/3.1/ref/urls/#url) function was [deprecated in Django 3.1](https://docs.djangoproject.com/en/3.1/releases/3.1/#id2) and is simply an alias for [re_path()](https://docs.djangoproject.com/en/3.1/ref/urls/#django.urls.re_path). So this PR replaces the former with the latter.

@nikolas @sdreher 