### PR TITLE
Add basic LTI 1.3 support - #636

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: build-and-test
 on: [push, workflow_dispatch]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
           python-version: ["3.8", "3.11"]

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,11 @@
-1.0.0
+1.1.0
+==================
+* Add LTI 1.3 support
+
+1.0.0 (2023-10-26)
 ==================
 * Django 3 compatability
 * No longer testing against Django 2.2
-
 
 0.4.7
 ==================

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ VE ?= ./ve
 REQUIREMENTS ?= test_reqs.txt
 SYS_PYTHON ?= python3
 PY_SENTINAL ?= $(VE)/sentinal
-WHEEL_VERSION ?= 0.41.2
-PIP_VERSION ?= 23.2.1
+WHEEL_VERSION ?= 0.42.0
+PIP_VERSION ?= 24.0
 MAX_COMPLEXITY ?= 7
 INTERFACE ?= localhost
 RUNSERVER_PORT ?= 8000
@@ -34,7 +34,7 @@ $(PY_SENTINAL):
 	$(PIP) install pip==$(PIP_VERSION)
 	$(PIP) install --upgrade setuptools
 	$(PIP) install wheel==$(WHEEL_VERSION)
-	$(PIP) install --no-deps --requirement $(REQUIREMENTS) --no-binary cryptography
+	$(PIP) install --no-deps --requirement $(REQUIREMENTS)
 	$(PIP) install "$(DJANGO)"
 	touch $@
 

--- a/lti_provider/tests/test_auth.py
+++ b/lti_provider/tests/test_auth.py
@@ -26,32 +26,32 @@ class LTIBackendTest(TestCase):
     def test_create_user(self):
         user = self.backend.create_user(self.request, self.lti, '12345')
         self.assertFalse(user.has_usable_password())
-        self.assertEquals(user.email, 'foo@bar.com')
-        self.assertEquals(user.get_full_name(), 'Foo Baz')
+        self.assertEqual(user.email, 'foo@bar.com')
+        self.assertEqual(user.get_full_name(), 'Foo Baz')
 
     def test_create_user_no_full_name(self):
         self.request.session.pop('lis_person_name_full')
         user = self.backend.create_user(self.request, self.lti, '12345')
-        self.assertEquals(user.get_full_name(), 'student')
+        self.assertEqual(user.get_full_name(), 'student')
 
     def test_create_user_empty_full_name(self):
         self.request.session['lis_person_name_full'] = ''
         user = self.backend.create_user(self.request, self.lti, '12345')
-        self.assertEquals(user.get_full_name(), 'student')
+        self.assertEqual(user.get_full_name(), 'student')
 
     def test_create_user_long_name(self):
         self.request.session['lis_person_name_full'] = (
             'Pneumonoultramicroscopicsilicovolcanoconiosis '
             'Supercalifragilisticexpialidocious')
         user = self.backend.create_user(self.request, self.lti, '12345')
-        self.assertEquals(
+        self.assertEqual(
             user.get_full_name(),
             'Pneumonoultramicroscopicsilico Supercalifragilisticexpialidoc')
 
     def test_find_or_create_user1(self):
         # via email
         user = UserFactory(email='foo@bar.com')
-        self.assertEquals(
+        self.assertEqual(
             self.backend.find_or_create_user(self.request, self.lti), user)
 
     def test_find_or_create_user2(self):
@@ -59,7 +59,7 @@ class LTIBackendTest(TestCase):
         username = 'uni123'
         self.request.session['custom_canvas_user_login_id'] = username
         user = UserFactory(username=username)
-        self.assertEquals(
+        self.assertEqual(
             self.backend.find_or_create_user(self.request, self.lti), user)
 
     def test_find_or_create_user3(self):
@@ -67,7 +67,7 @@ class LTIBackendTest(TestCase):
         self.request.session['oauth_consumer_key'] = '1234567890'
         username = self.backend.get_hashed_username(self.request, self.lti)
         user = UserFactory(username=username)
-        self.assertEquals(
+        self.assertEqual(
             self.backend.find_or_create_user(self.request, self.lti), user)
 
     def test_find_or_create_user4(self):
@@ -75,13 +75,13 @@ class LTIBackendTest(TestCase):
         self.request.session['oauth_consumer_key'] = '1234567890'
         user = self.backend.find_or_create_user(self.request, self.lti)
         self.assertFalse(user.has_usable_password())
-        self.assertEquals(user.email, 'foo@bar.com')
-        self.assertEquals(user.get_full_name(), 'Foo Baz')
+        self.assertEqual(user.email, 'foo@bar.com')
+        self.assertEqual(user.get_full_name(), 'Foo Baz')
 
         username = self.backend.get_hashed_username(self.request, self.lti)
-        self.assertEquals(user.username, username)
+        self.assertEqual(user.username, username)
 
     def test_get_user(self):
         user = UserFactory()
         self.assertIsNone(self.backend.get_user(1234))
-        self.assertEquals(self.backend.get_user(user.id), user)
+        self.assertEqual(self.backend.get_user(user.id), user)

--- a/lti_provider/tests/test_lti.py
+++ b/lti_provider/tests/test_lti.py
@@ -28,27 +28,27 @@ class LTITest(TestCase):
         self.emptyRequest.session.save()
 
     def test_init(self):
-        self.assertEquals(self.lti.request_type, 'initial')
-        self.assertEquals(self.lti.role_type, 'any')
+        self.assertEqual(self.lti.request_type, 'initial')
+        self.assertEqual(self.lti.role_type, 'any')
 
     def test_consumer_user_id(self):
         self.request.session['oauth_consumer_key'] = '1234567890'
-        self.assertEquals(
+        self.assertEqual(
             self.lti.consumer_user_id(self.request), '1234567890-student')
 
     def test_user_email(self):
         self.assertIsNone(self.lti.user_email(self.emptyRequest))
-        self.assertEquals(self.lti.user_email(self.request), 'foo@bar.com')
+        self.assertEqual(self.lti.user_email(self.request), 'foo@bar.com')
 
     def test_user_fullname(self):
-        self.assertEquals(self.lti.user_fullname(self.emptyRequest), '')
+        self.assertEqual(self.lti.user_fullname(self.emptyRequest), '')
 
-        self.assertEquals(self.lti.user_fullname(self.request), 'Foo Bar Baz')
+        self.assertEqual(self.lti.user_fullname(self.request), 'Foo Bar Baz')
 
     def test_user_roles(self):
-        self.assertEquals(self.lti.user_roles(self.emptyRequest), [])
+        self.assertEqual(self.lti.user_roles(self.emptyRequest), [])
 
-        self.assertEquals(self.lti.user_roles(self.request), [
+        self.assertEqual(self.lti.user_roles(self.request), [
             u'urn:lti:instrole:ims/lis/instructor',
             u'urn:lti:instrole:ims/lis/staff'])
 
@@ -57,7 +57,7 @@ class LTITest(TestCase):
 
     def test_consumers(self):
         with self.settings(PYLTI_CONFIG={'consumers': CONSUMERS}):
-            self.assertEquals(self.lti.consumers(), CONSUMERS)
+            self.assertEqual(self.lti.consumers(), CONSUMERS)
 
     def test_params(self):
         factory = RequestFactory()

--- a/lti_provider/tests/test_views.py
+++ b/lti_provider/tests/test_views.py
@@ -115,9 +115,9 @@ class LTIViewTest(TestCase):
         request = generate_lti_request()
 
         response = LTIRoutingView().dispatch(request)
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
-        self.assertEquals(response.url, reverse('lti-fail-auth'))
+        self.assertEqual(response.url, reverse('lti-fail-auth'))
         self.assertFalse(request.session.get(LTI_SESSION_KEY, False))
 
     def test_launch_invalid_course(self):
@@ -127,8 +127,8 @@ class LTIViewTest(TestCase):
             request = generate_lti_request()
 
             response = LTIRoutingView().dispatch(request)
-            self.assertEquals(response.status_code, 302)
-            self.assertEquals(response.url, reverse('lti-course-config'))
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response.url, reverse('lti-course-config'))
             self.assertTrue(request.session.get(LTI_SESSION_KEY, False))
 
     def test_launch(self):
@@ -143,17 +143,17 @@ class LTIViewTest(TestCase):
             view.request = request
 
             response = view.dispatch(request)
-            self.assertEquals(response.status_code, 302)
+            self.assertEqual(response.status_code, 302)
 
             landing = 'http://testserver/?lti_version=LTI-1p0&'
-            self.assertEquals(
+            self.assertEqual(
                 response.url, landing.format(ctx.lms_course_context))
 
             self.assertIsNotNone(request.session[LTI_SESSION_KEY])
             user = request.user
             self.assertFalse(user.has_usable_password())
-            self.assertEquals(user.email, 'foo@bar.com')
-            self.assertEquals(user.get_full_name(), 'Foo Baz')
+            self.assertEqual(user.email, 'foo@bar.com')
+            self.assertEqual(user.get_full_name(), 'Foo Baz')
             self.assertTrue(user in ctx.group.user_set.all())
             self.assertTrue(user in ctx.faculty_group.user_set.all())
 
@@ -170,7 +170,7 @@ class LTIViewTest(TestCase):
 
             response = view.dispatch(request)
             landing = 'http://testserver/lti/landing/{}/?lti_version=LTI-1p0&'
-            self.assertEquals(response.status_code, 302)
+            self.assertEqual(response.status_code, 302)
             self.assertTrue(
                 response.url,
                 landing.format(ctx.lms_course_context))
@@ -178,8 +178,8 @@ class LTIViewTest(TestCase):
             self.assertIsNotNone(request.session[LTI_SESSION_KEY])
             user = request.user
             self.assertFalse(user.has_usable_password())
-            self.assertEquals(user.email, 'foo@bar.com')
-            self.assertEquals(user.get_full_name(), 'Foo Baz')
+            self.assertEqual(user.email, 'foo@bar.com')
+            self.assertEqual(user.get_full_name(), 'Foo Baz')
             self.assertTrue(user in ctx.group.user_set.all())
             self.assertTrue(user in ctx.faculty_group.user_set.all())
 
@@ -194,8 +194,8 @@ class LTIViewTest(TestCase):
             view.request = request
 
             response = view.dispatch(request)
-            self.assertEquals(response.status_code, 302)
-            self.assertEquals(
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(
                 response.url,
                 'http://testserver/asset/embed/?return_url=/asset/'
                 '&lti_version=LTI-1p0&')
@@ -203,8 +203,8 @@ class LTIViewTest(TestCase):
             self.assertIsNotNone(request.session[LTI_SESSION_KEY])
             user = request.user
             self.assertFalse(user.has_usable_password())
-            self.assertEquals(user.email, 'foo@bar.com')
-            self.assertEquals(user.get_full_name(), 'Foo Baz')
+            self.assertEqual(user.email, 'foo@bar.com')
+            self.assertEqual(user.get_full_name(), 'Foo Baz')
             self.assertTrue(user in ctx.group.user_set.all())
             self.assertTrue(user in ctx.faculty_group.user_set.all())
 

--- a/lti_provider/urls.py
+++ b/lti_provider/urls.py
@@ -1,7 +1,11 @@
 from django.urls import re_path
 
-from lti_provider.views import LTIConfigView, LTILandingPage, LTIRoutingView, \
-    LTICourseEnableView, LTIPostGrade, LTIFailAuthorization, LTICourseConfigure
+from lti_provider.views import (
+    LTIConfigView, LTILandingPage, LTIRoutingView,
+    LTICourseEnableView, LTIPostGrade, LTIFailAuthorization,
+    LTICourseConfigure,
+    login, launch, get_jwks, configure
+)
 
 
 urlpatterns = [
@@ -17,5 +21,12 @@ urlpatterns = [
     re_path(r'^assignment/(?P<assignment_name>.*)/(?P<pk>\d+)/$',
             LTIRoutingView.as_view(), {}, 'lti-assignment-view'),
     re_path(r'^assignment/(?P<assignment_name>.*)/$',
-            LTIRoutingView.as_view(), {}, 'lti-assignment-view')
+            LTIRoutingView.as_view(), {}, 'lti-assignment-view'),
+
+    # New pylti1.3 routes
+    re_path(r'^login/$', login, name='lti-login'),
+    re_path(r'^launch/$', launch, name='lti-launch'),
+    re_path(r'^jwks/$', get_jwks, name='jwks'),
+    re_path(r'^configure/(?P<launch_id>[\w-]+)/$', configure,
+            name='lti-configure')
 ]

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "oauth2",
         "oauthlib",
         "pylti",
+        "pylti1p3",
         ],
     scripts=[],
     license="BSD",

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -22,3 +22,14 @@ importlib-metadata<7.1 # for flake8
 entrypoints==0.4
 typing_extensions==4.10.0
 pyparsing==3.1.2
+
+certifi==2024.2.2  # requests
+idna==3.6  # requests
+charset_normalizer==3.3.2  # requests
+urllib3==2.2.1  # requests
+requests==2.31.0  # pylti1p3
+pyjwt==2.8.0  # pylti1p3
+cffi==1.16.0  # cryptography
+cryptography==42.0.5  # jwcrypto
+jwcrypto==1.5.6  # pylti1p3
+pylti1p3==2.0.0


### PR DESCRIPTION
Preliminary launch steps are working, using updated code in our django-lti-provider-example library.