### PR TITLE
Add landing_url template context var to LTI 1.3 landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Add to ```INSTALLED_APPS``` in your ```settings.py```::
 
 ### Basic setup steps
 
-Add the URL route::
+Add the URL route:
 
 ```python
 path('lti/', include('lti_provider.urls'))
@@ -70,7 +70,7 @@ AUTHENTICATION_BACKENDS = [
 Complete a migration
 
 ```python
-   ./manage.py migrate
+./manage.py migrate
 ```
 
 ### Primary LTI config

--- a/lti_provider/templates/lti_provider/landing_page.html
+++ b/lti_provider/templates/lti_provider/landing_page.html
@@ -12,7 +12,9 @@
                 <div class="container">
                     <div class="jumbotron">
                         <h2>Custom Landing Page</h2>
-                        <p><a class="btn btn-default" href="{{landing_url}}" target="_blank">Launch Now</a></p>
+                        <p>
+                            <a class="btn btn-default" href="{{landing_url}}" target="_blank">Launch Now</a>
+                        </p>
                     </div>
                 </div>
             </div>

--- a/lti_provider/views.py
+++ b/lti_provider/views.py
@@ -305,6 +305,10 @@ def login(request):
 
 @require_POST
 def launch(request):
+    # TODO: make this course context aware - migrate functionality
+    # from LTILandingPage.get_context_data.
+    landing_url = settings.LTI_TOOL_CONFIGURATION['landing_url']
+
     tool_conf = get_tool_conf()
     launch_data_storage = get_launch_data_storage()
     message_launch = ExtendedDjangoMessageLaunch(
@@ -313,6 +317,7 @@ def launch(request):
     pprint.pprint(message_launch_data)
 
     return render(request, 'lti_provider/landing_page.html', {
+        'landing_url': landing_url,
         'page_title': 'Page Title',
         'is_deep_link_launch': message_launch.is_deep_link_launch(),
         'launch_data': message_launch.get_launch_data(),


### PR DESCRIPTION
I have the following template displaying in Canvas... I *think* through our new LTI 1.3 mechanisms:
![Screenshot_2024-04-12_16-32-14](https://github.com/ccnmtl/django-lti-provider/assets/59292/5c7259a4-cb6d-4867-b5fb-8a74f377916c)

This change hooks up the "Launch Now" button to connect the `landing_url` variable in django's LTI settings in this new `launch` view.

Note that this view is currently a function view as I based it off of this one: https://github.com/dmitry-viskov/pylti1.3-django-example/blob/master/game/game/views.py#L78

We can always migrate it to a class-based view like our LTI 1.1 views here, when and if necessary.