### PR TITLE
github actions: use python 3.12

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-          python-version: ["3.8", "3.11"]
+          python-version: ["3.8", "3.12"]
           django-version: ["4.2"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 24.04 uses python 3.12 (https://canonical.com/blog/canonical-releases-ubuntu-24-04-noble-numbat) so let's migrate our testing to that.