### PR TITLE
Remove dependency on oauth2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+1.1.1
+==================
+* Remove dependency on oauth2
+
 1.1.0 (2025-12-17)
 ==================
 * Add preliminary LTI 1.3 support

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 1.1.1
 ==================
 * Add django 5.2 test fix.
+* Remove dependency on oauth2
 
 1.1.0 (2025-12-17)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         "Django",
         "nameparser",
         "httplib2",
-        "oauth2",
         "oauthlib",
         "pylti",
         "pylti1p3",

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -1,7 +1,6 @@
 six==1.17.0
 nameparser==1.1.3
 httplib2==0.31.2
-oauth2==1.9.0.post1
 oauthlib==3.3.1
 pylti==0.7.0
 ipaddress==1.0.23


### PR DESCRIPTION
pylti is requiring this library.. so this is work-in-progress. We can possibly fork pylti, making use of these changes: https://github.com/mitodl/pylti/pull/101